### PR TITLE
Added fix for using watermark inside some element with display:none

### DIFF
--- a/jquery.watermark.js
+++ b/jquery.watermark.js
@@ -90,11 +90,15 @@
 			    e_top = ($elem.css('padding-top') != 'auto' ? parseInt($elem.css('padding-top')):0);
 		    }else{
 		        e_height = $elem.outerHeight();
-		        if(e_height <= 0)
+		        if(e_height <= 0 || $elem.height() <= 0)
 		        {
 		            e_height = ($elem.css('padding-top') != 'auto' ? parseInt($elem.css('padding-top')):0);
 		            e_height += ($elem.css('padding-bottom') != 'auto' ? parseInt($elem.css('padding-bottom')):0);
 		            e_height += ($elem.css('height') != 'auto' ? parseInt($elem.css('height')):0);
+		        }
+
+		        if (e_height <= 0) {
+		            e_height = $elem.css('line-height');
 		        }
 		    }    
 		    


### PR DESCRIPTION
For example when using watermark on text input that is inside div with display:none, watermark will be shown too high, because at the moment of calculating style for watermark, input height was 0, but outerHeight was 4.

jquery.watermark.min.js should also be updated, but I don't know what minifier you use.
